### PR TITLE
Use stable version of "Safe PHP" package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=7.2",
-    "thecodingmachine/safe": "^0.1.14",
+    "thecodingmachine/safe": "^1.0",
     "psr/event-dispatcher": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
Updating `thecodingmachine/safe` to stable version `^1.0`.

fixes #7 