### PR TITLE
Feat: Only 1 final flush by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,13 +171,17 @@ You can stop the workflow at any time.
 
 Use the `$state->stop()` method from the `EtlState` object as soon as your business logic requires it.
 
-Early flush
------------
+Flush frequency and early flushes
+---------------------------------
 
-You can define the flush frequency (defaults to 1) and optionally flush earlier than expected at any time:
+By default, the `flush()` method of your loader will be invoked at the end of the ETL, 
+meaning it will likely keep all loaded items in memory before dumping them to their final destination.
+
+Feel free to adjust a `flushFrequency` that fits your needs 
+and optionally trigger an early flush at any time during the ETL process:
 
 ```php
-$etl = (new EtlExecutor(options: new EtlConfiguration(flushEvery: 10)))
+$etl = (new EtlExecutor(options: new EtlConfiguration(flushFrequency: 10)))
     ->onLoad(
         function (LoadEvent $event) {
             if (/* whatever reason */) {

--- a/src/EtlConfiguration.php
+++ b/src/EtlConfiguration.php
@@ -4,10 +4,26 @@ declare(strict_types=1);
 
 namespace Bentools\ETL;
 
+use InvalidArgumentException;
+
+use function is_float;
+use function sprintf;
+
+use const INF;
+
 final readonly class EtlConfiguration
 {
+    public float|int $flushFrequency;
+
     public function __construct(
-        public int $flushEvery = 1,
+        float|int $flushEvery = INF,
     ) {
+        if (INF !== $flushEvery && is_float($flushEvery)) {
+            throw new InvalidArgumentException('Expected \\INF or int, float given.');
+        }
+        if ($flushEvery < 1) {
+            throw new InvalidArgumentException(sprintf('Expected positive integer > 0, got %d', $flushEvery));
+        }
+        $this->flushFrequency = $flushEvery;
     }
 }

--- a/tests/Unit/EtlConfigurationTest.php
+++ b/tests/Unit/EtlConfigurationTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BenTools\ETL\Tests\Unit;
+
+use Bentools\ETL\EtlConfiguration;
+use InvalidArgumentException;
+
+it('denies float values', function () {
+    new EtlConfiguration(flushEvery: 2.1);
+})->throws(InvalidArgumentException::class);
+
+it('denies negative values', function () {
+    new EtlConfiguration(flushEvery: -10);
+})->throws(InvalidArgumentException::class);

--- a/tests/Unit/Loader/JSONLoaderTest.php
+++ b/tests/Unit/Loader/JSONLoaderTest.php
@@ -4,20 +4,29 @@ declare(strict_types=1);
 
 namespace BenTools\ETL\Tests\Unit\Loader;
 
+use Bentools\ETL\EtlConfiguration;
 use Bentools\ETL\EtlExecutor;
 use Bentools\ETL\Loader\JSONLoader;
 use SplFileObject;
 
+use function dataset;
 use function dirname;
 use function expect;
 use function implode;
 use function sys_get_temp_dir;
 use function uniqid;
 
-it('loads items to a JSON file', function () {
+use const INF;
+
+dataset('config', [
+    new EtlConfiguration(flushEvery: INF),
+    new EtlConfiguration(flushEvery: 3),
+]);
+
+it('loads items to a JSON file', function (EtlConfiguration $options) {
     $cities = require dirname(__DIR__, 2).'/data/10-biggest-cities.php';
     $destination = 'file://'.sys_get_temp_dir().'/'.uniqid('10-biggest-cities_').'.json';
-    $executor = new EtlExecutor(loader: new JSONLoader($destination));
+    $executor = new EtlExecutor(loader: new JSONLoader($destination), options: $options);
     $output = $executor->process($cities)->output;
     expect($output)->toBe($destination);
 
@@ -27,15 +36,15 @@ it('loads items to a JSON file', function () {
     $expectedContent = implode('', [...new SplFileObject(dirname(__DIR__, 2).'/data/10-biggest-cities.json', 'r')]);
 
     expect($writtenContent)->toBe($expectedContent);
-});
+})->with('config');
 
-it('loads items to a JSON string', function () {
+it('loads items to a JSON string', function (EtlConfiguration $options) {
     $cities = require dirname(__DIR__, 2).'/data/10-biggest-cities.php';
-    $executor = new EtlExecutor(loader: new JSONLoader());
+    $executor = new EtlExecutor(loader: new JSONLoader(), options: $options);
     $output = $executor->process($cities)->output;
 
     // @phpstan-ignore-next-line
     $expectedContent = implode('', [...new SplFileObject(dirname(__DIR__, 2).'/data/10-biggest-cities.json', 'r')]);
 
     expect($output)->toBe($expectedContent);
-});
+})->with('config');


### PR DESCRIPTION
Changing default behavior: instead of invoking `flush()` after each loaded item, invoke `flush()` at the very end.
This is the default option, which is still configurable.