### PR TITLE
Refactor: Rename recipe main method

### DIFF
--- a/src/Internal/EtlBuilderTrait.php
+++ b/src/Internal/EtlBuilderTrait.php
@@ -63,6 +63,6 @@ trait EtlBuilderTrait
             $recipe = Recipe::fromCallable($recipe);
         }
 
-        return $recipe->fork($this);
+        return $recipe->decorate($this);
     }
 }

--- a/src/Recipe/LoggerRecipe.php
+++ b/src/Recipe/LoggerRecipe.php
@@ -48,7 +48,7 @@ final class LoggerRecipe extends Recipe
     ) {
     }
 
-    public function fork(EtlExecutor $executor): EtlExecutor
+    public function decorate(EtlExecutor $executor): EtlExecutor
     {
         return $executor
             ->onInit(fn (InitEvent $event) => $this->log($event, 'Initializing ETL...', ['state' => $event->state]),

--- a/src/Recipe/Recipe.php
+++ b/src/Recipe/Recipe.php
@@ -9,17 +9,17 @@ use Closure;
 
 abstract class Recipe
 {
-    abstract public function fork(EtlExecutor $executor): EtlExecutor;
+    abstract public function decorate(EtlExecutor $executor): EtlExecutor;
 
-    public static function fromCallable(callable $recipe): self
+    final public static function fromCallable(callable $recipe): self
     {
-        return new class(Closure::fromCallable($recipe)) extends Recipe {
+        return new class($recipe(...)) extends Recipe {
             public function __construct(
-                private Closure $recipe,
+                private readonly Closure $recipe,
             ) {
             }
 
-            public function fork(EtlExecutor $executor): EtlExecutor
+            public function decorate(EtlExecutor $executor): EtlExecutor
             {
                 return ($this->recipe)($executor);
             }


### PR DESCRIPTION
`Recipe::fork()` becomes `Recipe::decorate()` as it makes more sense.