### PR TITLE
Refactor: Make transform result internal stuff 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $etl = (new EtlExecutor())
     })
     ->loadInto(function (array $query, EtlState $state) {
         /** @var \PDO $pdo */
-        $pdo = $state->destination;
+        $pdo = $state->destination; // See below - $state->destination corresponds to the $destination argument of the $etl->process() method.
         [$sql, $params] = $query;
         $stmt = $pdo->prepare($sql);
         $stmt->execute($params);
@@ -131,6 +131,20 @@ As you can see:
 - You can use `EtlState.destination` to retrieve the second argument you passed yo `$etl->process()`.
 
 The `EtlState` object contains all elements relative to the state of your ETL workflow being running.
+
+Difference between `yield` and `return` in transformers
+------------------------------------------------------
+
+The `EtlExecutor::transformWith()` method accepts an unlimited number of transformers as arguments.
+
+When you chain transformers, keep in mind that every transformer will get:
+- Either the returned value passed from the previous transformer
+- Either an array of every yielded value from the previous transformer
+
+But the last transformer of the chain (or your only one transformer) is deterministic to know what will be passed to the loader (either a return  value, or a generator):
+- If your transformer `returns` a value, this value will be passed to the loader.
+- If your transformer `returns` an array of values (or whatever iterable), that return value will be passed to the loader.
+- If your transformer `yields` values, each yielded value will be passed to the loader.
 
 Using events
 ------------

--- a/src/EventDispatcher/Event/TransformEvent.php
+++ b/src/EventDispatcher/Event/TransformEvent.php
@@ -12,12 +12,9 @@ final class TransformEvent extends Event implements StoppableEventInterface
 {
     use StoppableEventTrait;
 
-    /**
-     * @param list<mixed> $items
-     */
     public function __construct(
         public readonly EtlState $state,
-        public array $items,
+        public mixed $transformResult,
     ) {
     }
 }

--- a/src/Internal/TransformResult.php
+++ b/src/Internal/TransformResult.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BenTools\ETL\Internal;
+
+use Generator;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * @internal
+ *
+ * @implements IteratorAggregate<mixed>
+ */
+final class TransformResult implements IteratorAggregate
+{
+    public mixed $value;
+    public bool $iterable;
+
+    private function __construct()
+    {
+    }
+
+    public function getIterator(): Traversable
+    {
+        if ($this->iterable) {
+            yield from $this->value;
+        } else {
+            yield $this->value;
+        }
+    }
+
+    public static function create(mixed $value): self
+    {
+        static $prototype;
+        $prototype ??= new self();
+
+        $that = clone $prototype;
+        if ($value instanceof Generator || $value instanceof self) {
+            $that->value = [...$value];
+            $that->iterable = true;
+        } else {
+            $that->value = $value;
+            $that->iterable = false;
+        }
+
+        return $that;
+    }
+}

--- a/src/Recipe/LoggerRecipe.php
+++ b/src/Recipe/LoggerRecipe.php
@@ -83,7 +83,7 @@ final class LoggerRecipe extends Recipe
                     [
                         'key' => $event->state->currentItemKey,
                         'state' => $event->state,
-                        'items' => $event->items,
+                        'items' => $event->transformResult,
                     ],
                 ),
                 $this->priorities[TransformEvent::class] ?? $this->defaultPriority,

--- a/src/Transformer/ChainTransformer.php
+++ b/src/Transformer/ChainTransformer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BenTools\ETL\Transformer;
 
 use BenTools\ETL\EtlState;
+use BenTools\ETL\Internal\TransformResult;
 
 final readonly class ChainTransformer implements TransformerInterface
 {
@@ -35,7 +36,7 @@ final readonly class ChainTransformer implements TransformerInterface
     {
         $output = $item;
         foreach ($this->transformers as $transformer) {
-            $output = $transformer->transform($output, $state);
+            $output = TransformResult::create($transformer->transform($output, $state))->value;
         }
 
         return $output;

--- a/tests/Behavior/Events/TransformEventTest.php
+++ b/tests/Behavior/Events/TransformEventTest.php
@@ -19,7 +19,7 @@ it('fires a transform event', function () {
         yield strtoupper($value);
     })
         ->onTransform(function (TransformEvent $e) use (&$transformedItems) {
-            $transformedItems = [...$transformedItems, ...$e->items];
+            $transformedItems = [...$transformedItems, ...$e->transformResult];
         });
 
     // When

--- a/tests/Behavior/SkipTest.php
+++ b/tests/Behavior/SkipTest.php
@@ -63,7 +63,7 @@ it('skips items during transformation', function () {
             $cities[] = $city;
         })
         ->onTransform(function (TransformEvent $event) {
-            if ('Tokyo' === [...$event->items][0]) {
+            if ('Tokyo' === [...$event->transformResult][0]) {
                 $event->state->skip();
             }
         });

--- a/tests/Behavior/StopTest.php
+++ b/tests/Behavior/StopTest.php
@@ -58,7 +58,7 @@ it('stops the process during transformation', function () {
             $cities[] = $city;
         })
         ->onTransform(function (TransformEvent $event) {
-            if ('Shanghai' === [...$event->items][0]) {
+            if ('Shanghai' === [...$event->transformResult][0]) {
                 $event->state->stop();
             }
         });

--- a/tests/Unit/Transformer/ChainTransformerTest.php
+++ b/tests/Unit/Transformer/ChainTransformerTest.php
@@ -23,7 +23,11 @@ it('chains transformers', function () {
             yield strtoupper($item);
         },
     ))
-        ->with(fn (Generator $items): array => [...$items])
+        ->with(function (array $items): array {
+            $items[] = 'hey';
+
+            return $items;
+        })
         ->with(fn (array $items): string => implode('-', $items));
 
     // When
@@ -32,8 +36,8 @@ it('chains transformers', function () {
 
     // Then
     expect($report->output)->toBe([
-        'oof-OOF',
-        'rab-RAB',
+        'oof-OOF-hey',
+        'rab-RAB-hey',
     ]);
 });
 
@@ -48,7 +52,11 @@ it('silently chains transformers', function () {
                 yield $item;
                 yield strtoupper($item);
             },
-            fn (Generator $items): array => [...$items],
+            function (array $items): array {
+                $items[] = 'hey';
+
+                return $items;
+            },
             fn (array $items): string => implode('-', $items)
         );
 
@@ -57,7 +65,7 @@ it('silently chains transformers', function () {
 
     // Then
     expect($report->output)->toBe([
-        'oof-OOF',
-        'rab-RAB',
+        'oof-OOF-hey',
+        'rab-RAB-hey',
     ]);
 });


### PR DESCRIPTION
- Renamed `TransformEvent::items` to `TransformEvent::transformResult` because the result could be a single item
- `TransformEvent::transformResult` can now be a single scalar result