### PR TITLE
Fix: skip/stop on next ticks

### DIFF
--- a/src/EtlExecutor.php
+++ b/src/EtlExecutor.php
@@ -212,7 +212,10 @@ final class EtlExecutor implements EventDispatcherInterface
      */
     private function terminate(EtlState $state): EtlState
     {
-        $this->consumeNextTick($state);
+        try {
+            $this->consumeNextTick($state);
+        } catch (SkipRequest|StopRequest) {
+        }
         $output = $this->flush($state->getLastVersion(), false);
 
         $state = $state->getLastVersion();


### PR DESCRIPTION
SkipRequest / StopRequest may not be caught in `consumeNextTicks()` whenever it is called by `terminate()`.