### PR TITLE
Feat: Generator fan-out in transform pipeline

### DIFF
--- a/tests/Unit/Transformer/ChainTransformerTest.php
+++ b/tests/Unit/Transformer/ChainTransformerTest.php
@@ -5,50 +5,14 @@ declare(strict_types=1);
 namespace BenTools\ETL\Tests\Unit\Transformer;
 
 use BenTools\ETL\EtlExecutor;
-use BenTools\ETL\Transformer\CallableTransformer;
 use BenTools\ETL\Transformer\ChainTransformer;
 use Generator;
 
-use function BenTools\ETL\chain;
 use function expect;
-use function implode;
 use function strrev;
 use function strtoupper;
 
-it('chains transformers', function () {
-    // Given
-    $input = ['foo', 'bar'];
-    $executor = new EtlExecutor(
-        transformer: new CallableTransformer(
-            fn (string $item): string => strrev($item),
-        ),
-    );
-    $executor = $executor->transformWith(
-        chain($executor->transformer)
-            ->with(function (string $item): Generator {
-                yield $item;
-                yield strtoupper($item);
-            })
-            ->with(fn (Generator $items): array => [...$items])
-            ->with(function (array $items): array {
-                $items[] = 'hey';
-
-                return $items;
-            })
-            ->with(fn (array $items): string => implode('-', $items)),
-    );
-
-    // When
-    $report = $executor->process($input);
-
-    // Then
-    expect($report->output)->toBe([
-        'oof-OOF-hey',
-        'rab-RAB-hey',
-    ]);
-});
-
-it('silently chains transformers', function () {
+it('chains transformers with generator fan-out', function () {
     // Given
     $input = ['foo', 'bar'];
 
@@ -59,23 +23,51 @@ it('silently chains transformers', function () {
                 yield $item;
                 yield strtoupper($item);
             },
-            fn (Generator $items): array => [...$items],
-            function (array $items): array {
-                $items[] = 'hey';
-
-                return $items;
-            },
-            fn (array $items) => yield implode('-', $items),
+            fn (string $item): string => "({$item})",
         );
 
     // When
     $report = $etl->process($input);
 
     // Then
-    expect($report->output)->toBe([
-        'oof-OOF-hey',
-        'rab-RAB-hey',
-    ]);
+    expect($report->output)->toBe(['(oof)', '(OOF)', '(rab)', '(RAB)']);
+});
+
+it('chains transformers without generators', function () {
+    // Given
+    $input = ['foo', 'bar'];
+
+    $etl = (new EtlExecutor())
+        ->transformWith(
+            fn (string $item): string => strrev($item),
+            fn (string $item): string => strtoupper($item),
+        );
+
+    // When
+    $report = $etl->process($input);
+
+    // Then
+    expect($report->output)->toBe(['OOF', 'RAB']);
+});
+
+it('chains transformers with generator fan-out using with()', function () {
+    // Given
+    $input = ['foo', 'bar'];
+
+    $chain = (new ChainTransformer(fn (string $item): string => strrev($item)))
+        ->with(function (string $item): Generator {
+            yield $item;
+            yield strtoupper($item);
+        })
+        ->with(fn (string $item): string => "({$item})");
+
+    $etl = (new EtlExecutor())->transformWith($chain);
+
+    // When
+    $report = $etl->process($input);
+
+    // Then
+    expect($report->output)->toBe(['(oof)', '(OOF)', '(rab)', '(RAB)']);
 });
 
 it('returns self', function () {


### PR DESCRIPTION
## Summary

- **ChainTransformer**: Generators are now consumed between each step of the chain. Each yielded item is passed individually to the next transformer (flatMap semantics), instead of passing the `Generator` object itself.
- **EtlExecutor**: A `TransformEvent` is now dispatched **per transformed item** instead of once for the entire batch. `SkipRequest` in a listener only skips the individual item, not all items from the generator.
- Scalar/array return values are unaffected — only `Generator` instances trigger fan-out.

## Breaking changes

| Impact | Description |
|--------|-------------|
| ⚠️ **ChainTransformer** | Chained transformers that type-hint `Generator $items` will break — they now receive individual items instead |
| ⚠️ **TransformEvent listeners** | `$event->transformResult` now contains a single item instead of a batch. `[...$e->transformResult]` returns `['item']` instead of `['item1', 'item2']` |
| ⚠️ **Skip in TransformEvent** | `skip()` now only skips the individual transformed item, not all items from the generator |
| ℹ️ **LoggerRecipe** | `onTransform` is called N times instead of 1 for a generator of N items (same `currentItemKey`). More verbose but more informative. No code change needed |

## Example

```php
$etl = (new EtlExecutor())
    ->transformWith(
        fn (string $item): string => strrev($item),
        function (string $item): Generator {
            yield $item;
            yield strtoupper($item);
        },
        fn (string $item): string => "({$item})",
    );

$report = $etl->process(['foo', 'bar']);
// Output: ['(oof)', '(OOF)', '(rab)', '(RAB)']
```

## Test plan

- [x] All 129 tests pass (237 assertions)
- [x] PHPStan clean
- [x] 100% code coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)