### PR TITLE
Feat: Batch transform support (BatchTransformerInterface)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,170 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`bentools/etl` is a PHP library implementing the Extract/Transform/Load pattern for data processing workflows. It's designed to be flexible, event-driven, and support both synchronous and asynchronous (ReactPHP) processing.
+
+**Core concept:** Extract data from a source, apply transformations, and load results into a destination.
+
+## Commands
+
+### Testing & Quality
+```bash
+# Run all CI checks (PHP-CS-Fixer, PHPStan, Pest with coverage)
+composer ci:check
+
+# Run tests only
+vendor/bin/pest
+
+# Run tests with coverage
+vendor/bin/pest --coverage
+
+# Run a single test file
+vendor/bin/pest tests/Behavior/FlushTest.php
+
+# Run PHPStan type checking
+vendor/bin/phpstan analyse
+
+# Run code style fixer
+vendor/bin/php-cs-fixer fix
+```
+
+### Requirements
+- PHP >=8.2
+- Tests use Pest (not PHPUnit syntax)
+- 100% code coverage expected before PRs
+
+## Architecture
+
+### Core Components
+
+**EtlExecutor** (`src/EtlExecutor.php`)
+- Main entry point for building and executing ETL workflows
+- Uses builder pattern via `EtlBuilderTrait` to chain extractors, transformers, and loaders
+- Dispatches events at each lifecycle stage (init, extract, transform, load, flush, end)
+- Handles exceptions through dedicated event types (ExtractException, TransformException, etc.)
+
+**EtlState** (`src/EtlState.php`)
+- Immutable state object passed through the entire workflow
+- Tracks: current item, indices, flush timing, loaded items count, output
+- Contains context (arbitrary data), source, and destination
+- Version system for state updates during processing
+
+**EtlConfiguration** (`src/EtlConfiguration.php`)
+- Configuration object for flush frequency, batch size, and other options
+- `flushEvery` - Controls how often the loader flushes (default: INF)
+- `batchSize` - Controls how many items are grouped for batch transformation (default: 1)
+
+### Three Main Interfaces
+
+1. **ExtractorInterface** (`src/Extractor/`)
+   - `extract(EtlState $state): iterable` - Returns an iterable of items to process
+   - Built-in: CSV, JSON, FileExtractor, STDINExtractor, IterableExtractor, ReactStreamExtractor
+
+2. **TransformerInterface** (`src/Transformer/`)
+   - `transform(mixed $item, EtlState $state): mixed` - Transforms extracted items
+   - Return value can be a single value, an array, or a generator (yield)
+   - Yielded items generate multiple loads from a single extracted item
+   - Built-in: CallableTransformer, ChainTransformer, NullTransformer
+
+3. **BatchTransformerInterface** (`src/Transformer/`)
+   - `transform(array $items, EtlState $state): Generator` - Transforms a batch of items at once
+   - Separate interface from `TransformerInterface` (does NOT extend it)
+   - Activated when `batchSize` is set in `EtlConfiguration` and transformer implements this interface
+   - Each yielded value becomes an individual item for the load phase
+   - Built-in: CallableBatchTransformer
+
+4. **LoaderInterface** (`src/Loader/`)
+   - `load(mixed $item, EtlState $state): void` - Loads transformed items
+   - `flush(bool $isEarly, EtlState $state): mixed` - Called at flush frequency or end
+   - Built-in: InMemoryLoader, CSV, JSON, DoctrineORM, STDOUTLoader
+
+### Event System
+
+**Event dispatching** (`src/EventDispatcher/`)
+- Custom PSR-14 implementation with priority support
+- Events: InitEvent, StartEvent, ExtractEvent, TransformEvent, BeforeLoadEvent, LoadEvent, FlushEvent, EndEvent
+- Exception events: ExtractExceptionEvent, TransformExceptionEvent, LoadExceptionEvent, FlushExceptionEvent
+- Use `->on{EventName}(callable $listener, int $priority = 0)` on EtlExecutor
+
+**Control flow exceptions:**
+- `SkipRequest` - Skip current item, continue processing
+- `StopRequest` - Stop entire workflow immediately
+
+### Processors
+
+**ProcessorInterface** (`src/Processor/`)
+- `IterableProcessor` - Default synchronous processing
+- `ReactStreamProcessor` - Async processing with ReactPHP streams (experimental)
+
+### Recipes
+
+**Recipe** (`src/Recipe/`)
+- Reusable workflow configurations (combine extractors, transformers, loaders, event listeners)
+- `FilterRecipe` - Skip/exclude items based on callable filter
+- `LoggerRecipe` - PSR-3 logging integration
+
+### Utility Functions
+
+`src/functions.php` provides helper functions:
+- `extractFrom()` - Create executor starting with extractor
+- `transformWith()` - Create executor starting with transformer
+- `loadInto()` - Create executor starting with loader
+- `withRecipe()` - Create executor with recipe
+- `chain()` - Chain multiple extractors/transformers/loaders
+- `stdIn()` / `stdOut()` - STDIN/STDOUT helpers
+- `skipWhen()` - Conditional skip recipe
+
+## Key Patterns
+
+### Immutability & Cloning
+- EtlExecutor uses `ClonableTrait` - all builder methods return clones
+- EtlState has version tracking - always get latest via `$state->getLastVersion()`
+
+### Fluent Building
+```php
+$executor = (new EtlExecutor())
+    ->extractFrom($extractor)
+    ->transformWith($transformer)
+    ->loadInto($loader)
+    ->onTransform(fn($event) => /* ... */)
+    ->process($source, $destination);
+```
+
+### NextTick Callbacks
+- `$state->nextTick(callable $callback)` - Schedule callback after current item
+- Useful for deferring operations or cleanup
+- Consumed between items and guaranteed to run even if workflow stops
+
+### Batch Transform
+- Configure via `new EtlConfiguration(batchSize: N)` to group N items per batch
+- Requires a transformer implementing `BatchTransformerInterface` (separate from `TransformerInterface`)
+- Processing flow: items are chunked via `iterable_chunk()`, then for each chunk:
+  1. ExtractEvent fires per item (items can be skipped individually)
+  2. `transform(array $items, EtlState $state): Generator` is called once for the whole batch
+  3. Each yielded result goes through TransformEvent → Load individually
+- `nextTick` callbacks are consumed between batches, not between items within a batch
+- When `batchSize` is set but transformer is not `BatchTransformerInterface`, batching is ignored
+- Note: `$state->currentItemKey` during Transform/Load events points to the last item of the batch
+
+### Flush Timing
+- Configurable via `new EtlConfiguration(flushEvery: N)`
+- `flush()` called when: frequency threshold reached, or at end (with `$isEarly = false`)
+- Early flush = during processing, final flush = at termination
+
+## Testing Patterns
+
+- Tests are organized in `tests/Behavior/` and `tests/Unit/`
+- Use Pest syntax (`test()`, `expect()`, `it()`)
+- Mock with Mockery when needed
+- Coverage is tracked - don't reduce it
+
+## Development Notes
+
+- PHP 8.2+ features are welcome (readonly properties, enums, etc.)
+- Prefer immutability and value objects
+- Event listeners should be side-effect free when possible
+- Transformers returning generators (yield) allow 1-to-many transformations
+- Loaders can implement `ConditionalLoaderInterface` to skip certain items

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Table of Contents
 - [Advanced Usage](doc/advanced_usage.md)
     - [Creating your own Extractor / Transformers / Loaders](doc/advanced_usage.md#creating-your-own-extractor--transformers--loaders)
     - [Difference between yield and return in transformers](doc/advanced_usage.md#difference-between-yield-and-return-in-transformers)
+    - [Batch transforms](doc/advanced_usage.md#batch-transforms)
     - [Next tick](doc/advanced_usage.md#next-tick)
     - [Chaining extractors / transformers / loaders](doc/advanced_usage.md#chaining-extractors--transformers--loaders)
     - [Reading from STDIN / Writing to STDOUT](doc/advanced_usage.md#reading-from-stdin--writing-to-stdout)

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "php": ">=8.2",
     "psr/event-dispatcher": "^1.0",
     "psr/log": "^3.0",
+    "bentools/iterable-functions": "^2.1",
     "symfony/options-resolver": "@stable"
   },
   "require-dev": {
-    "bentools/iterable-functions": "^2.1",
     "doctrine/orm": "^2.16",
     "friendsofphp/php-cs-fixer": "^3.35",
     "mockery/mockery": "^1.6",

--- a/src/EtlConfiguration.php
+++ b/src/EtlConfiguration.php
@@ -14,9 +14,11 @@ use const INF;
 class EtlConfiguration
 {
     public readonly float|int $flushFrequency;
+    public readonly int $batchSize;
 
     public function __construct(
         float|int $flushEvery = INF,
+        int $batchSize = 1,
     ) {
         if (INF !== $flushEvery && is_float($flushEvery)) {
             throw new InvalidArgumentException('Expected \\INF or int, float given.');
@@ -24,6 +26,10 @@ class EtlConfiguration
         if ($flushEvery < 1) {
             throw new InvalidArgumentException(sprintf('Expected positive integer > 0, got %d', $flushEvery));
         }
+        if ($batchSize < 1) {
+            throw new InvalidArgumentException(sprintf('Expected positive integer > 0 for batchSize, got %d', $batchSize));
+        }
         $this->flushFrequency = $flushEvery;
+        $this->batchSize = $batchSize;
     }
 }

--- a/src/Internal/EtlBuilderTrait.php
+++ b/src/Internal/EtlBuilderTrait.php
@@ -14,6 +14,7 @@ use BenTools\ETL\Loader\ChainLoader;
 use BenTools\ETL\Loader\LoaderInterface;
 use BenTools\ETL\Processor\ProcessorInterface;
 use BenTools\ETL\Recipe\Recipe;
+use BenTools\ETL\Transformer\BatchTransformerInterface;
 use BenTools\ETL\Transformer\CallableTransformer;
 use BenTools\ETL\Transformer\ChainTransformer;
 use BenTools\ETL\Transformer\TransformerInterface;
@@ -53,9 +54,13 @@ trait EtlBuilderTrait
     }
 
     public function transformWith(
-        TransformerInterface|callable $transformer,
+        TransformerInterface|BatchTransformerInterface|callable $transformer,
         TransformerInterface|callable ...$transformers,
     ): self {
+        if ($transformer instanceof BatchTransformerInterface) {
+            return $this->cloneWith(['transformer' => $transformer]);
+        }
+
         $transformers = [$transformer, ...$transformers];
 
         foreach ($transformers as $t => $_transformer) {

--- a/src/Transformer/BatchTransformerInterface.php
+++ b/src/Transformer/BatchTransformerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BenTools\ETL\Transformer;
+
+use BenTools\ETL\EtlState;
+use Generator;
+
+interface BatchTransformerInterface
+{
+    /**
+     * Transform a batch of items at once.
+     *
+     * Each yielded value becomes an individual item for the load phase.
+     *
+     * @param list<mixed> $items
+     */
+    public function transform(array $items, EtlState $state): Generator;
+}

--- a/src/Transformer/CallableBatchTransformer.php
+++ b/src/Transformer/CallableBatchTransformer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BenTools\ETL\Transformer;
+
+use BenTools\ETL\EtlState;
+use Closure;
+use Generator;
+
+final readonly class CallableBatchTransformer implements BatchTransformerInterface
+{
+    public Closure $closure;
+
+    public function __construct(
+        callable $callback,
+    ) {
+        $this->closure = $callback(...);
+    }
+
+    public function transform(array $items, EtlState $state): Generator
+    {
+        yield from ($this->closure)($items, $state);
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -15,6 +15,7 @@ use BenTools\ETL\Processor\ReactStreamProcessor;
 use BenTools\ETL\Recipe\FilterRecipe;
 use BenTools\ETL\Recipe\FilterRecipeMode;
 use BenTools\ETL\Recipe\Recipe;
+use BenTools\ETL\Transformer\BatchTransformerInterface;
 use BenTools\ETL\Transformer\ChainTransformer;
 use BenTools\ETL\Transformer\TransformerInterface;
 use Iterator;
@@ -61,7 +62,7 @@ function extractFrom(ExtractorInterface|callable $extractor, ExtractorInterface|
 }
 
 function transformWith(
-    TransformerInterface|callable $transformer,
+    TransformerInterface|BatchTransformerInterface|callable $transformer,
     TransformerInterface|callable ...$transformers,
 ): EtlExecutor {
     return (new EtlExecutor())->transformWith(...func_get_args());

--- a/tests/Behavior/BatchTransformTest.php
+++ b/tests/Behavior/BatchTransformTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BenTools\ETL\Tests\Behavior;
+
+use BenTools\ETL\EtlConfiguration;
+use BenTools\ETL\EtlExecutor;
+use BenTools\ETL\EventDispatcher\Event\ExtractEvent;
+use BenTools\ETL\EventDispatcher\Event\TransformEvent;
+use BenTools\ETL\Transformer\CallableBatchTransformer;
+use Generator;
+
+use function strtoupper;
+
+it('transforms items in batches', function () {
+    // Given
+    $items = ['foo', 'bar', 'baz', 'qux'];
+
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            fn (array $items) => array_map(strtoupper(...), $items),
+        ))
+        ->withOptions(new EtlConfiguration(batchSize: 2));
+
+    // When
+    $report = $executor->process($items);
+
+    // Then
+    expect($report->output)->toBe(['FOO', 'BAR', 'BAZ', 'QUX']);
+});
+
+it('handles partial last batch', function () {
+    // Given
+    $items = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+
+    $batchSizes = [];
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            function (array $items) use (&$batchSizes) {
+                $batchSizes[] = count($items);
+
+                return array_map(strtoupper(...), $items);
+            },
+        ))
+        ->withOptions(new EtlConfiguration(batchSize: 3));
+
+    // When
+    $report = $executor->process($items);
+
+    // Then
+    expect($report->output)->toBe(['A', 'B', 'C', 'D', 'E', 'F', 'G']);
+    expect($batchSizes)->toBe([3, 3, 1]);
+});
+
+it('handles empty input', function () {
+    // Given
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            fn (array $items) => array_map(strtoupper(...), $items),
+        ))
+        ->withOptions(new EtlConfiguration(batchSize: 5));
+
+    // When
+    $report = $executor->process([]);
+
+    // Then
+    expect($report->output)->toBeNull();
+});
+
+it('skips items during extract phase', function () {
+    // Given
+    $items = ['foo', 'bar', 'baz', 'qux'];
+
+    $batchSizes = [];
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            function (array $items) use (&$batchSizes) {
+                $batchSizes[] = count($items);
+
+                return array_map(strtoupper(...), $items);
+            },
+        ))
+        ->onExtract(function (ExtractEvent $event) {
+            if ('bar' === $event->item) {
+                $event->state->skip();
+            }
+        })
+        ->withOptions(new EtlConfiguration(batchSize: 2));
+
+    // When
+    $report = $executor->process($items);
+
+    // Then - 'bar' was skipped, so batch 1 only has 'foo', batch 2 has 'baz'+'qux'
+    expect($report->output)->toBe(['FOO', 'BAZ', 'QUX']);
+    expect($batchSizes)->toBe([1, 2]);
+});
+
+it('stops processing during extract phase', function () {
+    // Given
+    $items = ['foo', 'bar', 'baz', 'qux'];
+
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            fn (array $items) => array_map(strtoupper(...), $items),
+        ))
+        ->onExtract(function (ExtractEvent $event) {
+            if ('baz' === $event->item) {
+                $event->state->stop();
+            }
+        })
+        ->withOptions(new EtlConfiguration(batchSize: 4));
+
+    // When
+    $report = $executor->process($items);
+
+    // Then - stopped at 'baz', only 'foo' and 'bar' were processed
+    expect($report->output)->toBe(['FOO', 'BAR']);
+});
+
+it('skips items during transform phase', function () {
+    // Given
+    $items = ['foo', 'bar', 'baz'];
+
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            fn (array $items) => array_map(strtoupper(...), $items),
+        ))
+        ->onTransform(function (TransformEvent $event) {
+            if ('BAR' === [...$event->transformResult][0]) {
+                $event->state->skip();
+            }
+        })
+        ->withOptions(new EtlConfiguration(batchSize: 3));
+
+    // When
+    $report = $executor->process($items);
+
+    // Then
+    expect($report->output)->toBe(['FOO', 'BAZ']);
+});
+
+it('supports fan-out in batch mode', function () {
+    // Given
+    $items = ['foo', 'bar'];
+
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            function (array $items): Generator {
+                foreach ($items as $item) {
+                    yield $item;
+                    yield strtoupper($item);
+                }
+            },
+        ))
+        ->withOptions(new EtlConfiguration(batchSize: 2));
+
+    // When
+    $report = $executor->process($items);
+
+    // Then
+    expect($report->output)->toBe(['foo', 'FOO', 'bar', 'BAR']);
+});
+
+it('works with batchSize of 1', function () {
+    // Given
+    $items = ['foo', 'bar'];
+
+    $batchSizes = [];
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            function (array $items) use (&$batchSizes) {
+                $batchSizes[] = count($items);
+
+                return array_map(strtoupper(...), $items);
+            },
+        ))
+        ->withOptions(new EtlConfiguration(batchSize: 1));
+
+    // When
+    $report = $executor->process($items);
+
+    // Then - batchSize=1 still uses batch path with chunks of 1
+    expect($report->output)->toBe(['FOO', 'BAR']);
+    expect($batchSizes)->toBe([1, 1]);
+});
+
+it('ignores batchSize when transformer is not BatchTransformerInterface', function () {
+    // Given
+    $items = ['foo', 'bar', 'baz'];
+
+    $executor = (new EtlExecutor())
+        ->transformWith(fn (mixed $item) => strtoupper($item))
+        ->withOptions(new EtlConfiguration(batchSize: 2));
+
+    // When
+    $report = $executor->process($items);
+
+    // Then - works normally, no batching
+    expect($report->output)->toBe(['FOO', 'BAR', 'BAZ']);
+});
+
+it('works with flushFrequency', function () {
+    // Given
+    $items = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+    $flushCount = 0;
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            fn (array $items) => array_map(strtoupper(...), $items),
+        ))
+        ->onFlush(function () use (&$flushCount) {
+            ++$flushCount;
+        })
+        ->withOptions(new EtlConfiguration(batchSize: 3, flushEvery: 3));
+
+    // When
+    $report = $executor->process($items);
+
+    // Then
+    expect($report->output)->toBe(['A', 'B', 'C', 'D', 'E', 'F']);
+    expect($flushCount)->toBe(3); // flush at 3 items + flush at 6 items + final flush
+});
+
+it('fires extract events for each item individually', function () {
+    // Given
+    $items = ['foo', 'bar', 'baz'];
+
+    $extractedItems = [];
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            fn (array $items) => array_map(strtoupper(...), $items),
+        ))
+        ->onExtract(function (ExtractEvent $event) use (&$extractedItems) {
+            $extractedItems[] = $event->item;
+        })
+        ->withOptions(new EtlConfiguration(batchSize: 3));
+
+    // When
+    $executor->process($items);
+
+    // Then - ExtractEvent fires per item, not per batch
+    expect($extractedItems)->toBe(['foo', 'bar', 'baz']);
+});
+
+it('fires transform events for each result individually', function () {
+    // Given
+    $items = ['foo', 'bar'];
+
+    $transformedItems = [];
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            fn (array $items) => array_map(strtoupper(...), $items),
+        ))
+        ->onTransform(function (TransformEvent $event) use (&$transformedItems) {
+            $transformedItems[] = [...$event->transformResult][0];
+        })
+        ->withOptions(new EtlConfiguration(batchSize: 2));
+
+    // When
+    $executor->process($items);
+
+    // Then - TransformEvent fires per result, not per batch
+    expect($transformedItems)->toBe(['FOO', 'BAR']);
+});
+
+it('handles batchSize larger than total items', function () {
+    // Given
+    $items = ['foo', 'bar'];
+
+    $batchSizes = [];
+    $executor = (new EtlExecutor())
+        ->transformWith(new CallableBatchTransformer(
+            function (array $items) use (&$batchSizes) {
+                $batchSizes[] = count($items);
+
+                return array_map(strtoupper(...), $items);
+            },
+        ))
+        ->withOptions(new EtlConfiguration(batchSize: 100));
+
+    // When
+    $report = $executor->process($items);
+
+    // Then - single batch with all items
+    expect($report->output)->toBe(['FOO', 'BAR']);
+    expect($batchSizes)->toBe([2]);
+});

--- a/tests/Unit/EtlConfigurationTest.php
+++ b/tests/Unit/EtlConfigurationTest.php
@@ -14,3 +14,11 @@ it('denies float values', function () {
 it('denies negative values', function () {
     new EtlConfiguration(flushEvery: -10);
 })->throws(InvalidArgumentException::class);
+
+it('denies negative batchSize values', function () {
+    new EtlConfiguration(batchSize: -1);
+})->throws(InvalidArgumentException::class);
+
+it('denies zero batchSize', function () {
+    new EtlConfiguration(batchSize: 0);
+})->throws(InvalidArgumentException::class);

--- a/tests/Unit/Transformer/CallableBatchTransformerTest.php
+++ b/tests/Unit/Transformer/CallableBatchTransformerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BenTools\ETL\Tests\Unit\Transformer;
+
+use BenTools\ETL\EtlState;
+use BenTools\ETL\Transformer\CallableBatchTransformer;
+
+use function strtoupper;
+
+it('converts a callable to a batch transformer', function () {
+    // Given
+    $state = new EtlState();
+    $transformer = new CallableBatchTransformer(
+        fn (array $items) => array_map(strtoupper(...), $items),
+    );
+
+    // When
+    $transformed = $transformer->transform(['foo', 'bar'], $state);
+
+    // Then
+    expect([...$transformed])->toBe(['FOO', 'BAR']);
+});
+
+it('handles single-item batches', function () {
+    // Given
+    $state = new EtlState();
+    $transformer = new CallableBatchTransformer(
+        fn (array $items) => array_map(strtoupper(...), $items),
+    );
+
+    // When
+    $transformed = $transformer->transform(['foo'], $state);
+
+    // Then
+    expect([...$transformed])->toBe(['FOO']);
+});
+
+it('handles empty batches', function () {
+    // Given
+    $state = new EtlState();
+    $transformer = new CallableBatchTransformer(
+        fn (array $items) => array_map(strtoupper(...), $items),
+    );
+
+    // When
+    $transformed = $transformer->transform([], $state);
+
+    // Then
+    expect([...$transformed])->toBe([]);
+});


### PR DESCRIPTION
## Summary

- Add `BatchTransformerInterface` — a new interface (separate from `TransformerInterface`) for transforming items in batches instead of one-by-one
- Add `CallableBatchTransformer` — callable-based implementation
- Add `batchSize` option to `EtlConfiguration` to control chunk size
- Modify `IterableProcessor` to chunk extracted items via `iterable_chunk()` when a batch transformer is detected
- Add `processItemBatch()` to `EtlExecutor` for batch processing orchestration
- Move `bentools/iterable-functions` from `require-dev` to `require`

### Use case

Transformers that make HTTP calls can now send N requests concurrently instead of waiting for each response sequentially:

```php
$executor = (new EtlExecutor())
    ->transformWith(new CallableBatchTransformer(
        function (array $items, EtlState $state): array {
            return $httpClient->sendConcurrent(
                array_map(fn ($item) => new Request('GET', $item['url']), $items)
            );
        }
    ))
    ->withOptions(new EtlConfiguration(batchSize: 10))
    ->process($source);
```

### Design decisions

- `BatchTransformerInterface` does **not** extend `TransformerInterface` (PHP prevents parameter type narrowing `mixed` → `array`)
- Batch mode activates when transformer implements `BatchTransformerInterface` (regardless of `batchSize`)
- `nextTick` callbacks are consumed between batches, not between items within a batch
- `SkipRequest` during extraction removes the item from the batch; `StopRequest` processes collected items then stops
- When transformer is not `BatchTransformerInterface`, `batchSize` is ignored (zero behavioral change)

## Test plan

- [x] Happy path: N items, batch size M, all transformed correctly
- [x] Partial last batch (7 items, batchSize=3 → batches of 3, 3, 1)
- [x] Empty input
- [x] SkipRequest during ExtractEvent → item removed from batch
- [x] StopRequest during ExtractEvent → processes collected items, then stops
- [x] SkipRequest during TransformEvent → result skipped
- [x] Fan-out in batch mode (transformer yields more results than inputs)
- [x] batchSize=1 with BatchTransformerInterface → works with chunks of 1
- [x] Non-batch transformer with batchSize > 1 → gracefully ignored
- [x] Integration with flushFrequency
- [x] ExtractEvent fires per item, TransformEvent fires per result
- [x] batchSize larger than total items → single batch
- [x] EtlConfiguration validation (batchSize < 1 throws)
- [x] All 147 tests pass, PHPStan clean, 99.3% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)